### PR TITLE
:arrow_up: Use composer v2 in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN command -v php
 RUN curl -sS https://getcomposer.org/installer | php -- --1
 RUN mv composer.phar /usr/local/bin/composer && \
     chmod +x /usr/local/bin/composer && \
-    composer self-update
+    composer self-update --2
 RUN command -v composer
 
 # Node.js

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker image for Continuous Integration
 
 ## System information
-  * Ubuntu 16.04
+  * Ubuntu 18.04
 
 ## Installed packages
   * ssh
@@ -9,7 +9,7 @@
   * rsync
   * curl
   * wget
-  * PHP 7.2
+  * PHP 7.4
     * MySQL
     * sqlite
     * Xdebug
@@ -20,7 +20,7 @@
     * xml
     * bcmath
     * intl
-  * Composer
+  * Composer v2
   * PHPUnit
-  * Node.js 9.x
+  * Node.js 16.x
   * Yarn


### PR DESCRIPTION
just adding the `--2` flag in the composer self-update in order to use composer v2 and adjust documentation in the README